### PR TITLE
Remove unused import

### DIFF
--- a/atomic.go
+++ b/atomic.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 // WriteFile atomically writes the contents of r to the specified filepath.  If


### PR DESCRIPTION
The current project does not compile because this "time" import is not used.