### PR TITLE
Only issue chmod if the mode is different

### DIFF
--- a/atomic.go
+++ b/atomic.go
@@ -41,14 +41,21 @@ func WriteFile(filename string, r io.Reader) (err error) {
 
 	// get the file mode from the original file and use that for the replacement
 	// file, too.
-	info, err := os.Stat(filename)
+	destInfo, err := os.Stat(filename)
 	if os.IsNotExist(err) {
 		// no original file
 	} else if err != nil {
 		return err
 	} else {
-		if err := os.Chmod(name, info.Mode()); err != nil {
-			return fmt.Errorf("can't set filemode on tempfile %q: %v", name, err)
+		sourceInfo, err := os.Stat(name)
+		if err != nil {
+			return err
+		}
+
+		if sourceInfo.Mode() != destInfo.Mode() {
+			if err := os.Chmod(name, destInfo.Mode()); err != nil {
+				return fmt.Errorf("can't set filemode on tempfile %q: %v", name, err)
+			}
 		}
 	}
 	if err := ReplaceFile(name, filename); err != nil {


### PR DESCRIPTION
We've run into issues with strange filesystems (like vfat) that don't allow any `os.Chmod()` to succeed. To prevent this from returning an error, we are adding a check to not do the `os.Chmod()` if the source and destination permissions are the same.