### PR TITLE
Add support for changing the default file mode using options pattern (fixes natefinch/atomic#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ WriteFile atomically writes the contents of r to the specified filepath.  If an
 error occurs, the target file is guaranteed to be either fully written, or not
 written at all.  WriteFile overwrites any file that exists at the location (but
 only if the write fully succeeds, otherwise the existing file is unmodified).
-Permissions are copied from an existing file or the FileMode option can be given
-to be used instead of the default `0600` from ioutil.TempFile().
+Permissions are copied from an existing file or the DefaultFileMode option can
+be given to be used instead of the default `0600` from ioutil.TempFile().

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ change either file.
 
 ## func WriteFile
 ``` go
-func WriteFile(filename string, r io.Reader) (err error)
+func WriteFile(filename string, r io.Reader, opts ...Option) (err error)
 ```
-WriteFile atomically writes the contents of r to the specified filepath.  If
-an error occurs, the target file is guaranteed to be either fully written, or
-not written at all.  WriteFile overwrites any file that exists at the
-location (but only if the write fully succeeds, otherwise the existing file
-is unmodified).
-
+WriteFile atomically writes the contents of r to the specified filepath.  If an
+error occurs, the target file is guaranteed to be either fully written, or not
+written at all.  WriteFile overwrites any file that exists at the location (but
+only if the write fully succeeds, otherwise the existing file is unmodified).
+Permissions are copied from an existing file or the FileMode option can be given
+to be used instead of the default `0600` from ioutil.TempFile().

--- a/atomic.go
+++ b/atomic.go
@@ -10,16 +10,16 @@ import (
 )
 
 type FileOptions struct {
-	mode os.FileMode
+	defaultMode os.FileMode
 }
 
 type Option func(*FileOptions)
 
 // FileMode can be given as an argument to `WriteFile()` to change the default
 // file mode from the default value of ioutil.TempFile() (`0600`).
-func FileMode(mode os.FileMode) Option {
+func DefaultFileMode(mode os.FileMode) Option {
 	return func(opts *FileOptions) {
-		opts.mode = mode
+		opts.defaultMode = mode
 	}
 }
 
@@ -65,9 +65,9 @@ func WriteFile(filename string, r io.Reader, opts ...Option) (err error) {
 		return fmt.Errorf("can't flush tempfile %q: %v", name, err)
 	}
 	// when optional mode was given change default mode of temp file.
-	if fopts.mode != 0 {
-		if err := f.Chmod(fopts.mode); err != nil {
-			return fmt.Errorf("cannot change file mode %q: %v", name, err);
+	if fopts.defaultMode != 0 {
+		if err := f.Chmod(fopts.defaultMode); err != nil {
+			return fmt.Errorf("cannot change file mode %q: %v", name, err)
 		}
 	}
 	if err := f.Close(); err != nil {

--- a/atomic.go
+++ b/atomic.go
@@ -16,6 +16,8 @@ type FileOptions struct {
 
 type Option func(*FileOptions)
 
+// FileMode can be given as an argument to `WriteFile()` to change the default
+// file mode from the default value of ioutil.TempFile() (`0600`).
 func FileMode(mode fs.FileMode) Option {
 	return func(opts *FileOptions) {
 		opts.mode = mode

--- a/atomic.go
+++ b/atomic.go
@@ -5,20 +5,19 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"io/fs"
 	"os"
 	"path/filepath"
 )
 
 type FileOptions struct {
-	mode fs.FileMode
+	mode os.FileMode
 }
 
 type Option func(*FileOptions)
 
 // FileMode can be given as an argument to `WriteFile()` to change the default
 // file mode from the default value of ioutil.TempFile() (`0600`).
-func FileMode(mode fs.FileMode) Option {
+func FileMode(mode os.FileMode) Option {
 	return func(opts *FileOptions) {
 		opts.mode = mode
 	}

--- a/atomic.go
+++ b/atomic.go
@@ -27,9 +27,9 @@ func DefaultFileMode(mode os.FileMode) Option {
 // an error occurs, the target file is guaranteed to be either fully written, or
 // not written at all.  WriteFile overwrites any file that exists at the
 // location (but only if the write fully succeeds, otherwise the existing file
-// is unmodified).  Permissions are copied from an existing file or the FileMode
-// option can be given to be used instead of the default `0600` from
-// ioutil.TempFile().
+// is unmodified).  Permissions are copied from an existing file or the
+// DefaultFileMode option can be given to be used instead of the default `0600`
+// from ioutil.TempFile().
 func WriteFile(filename string, r io.Reader, opts ...Option) (err error) {
 	fopts := &FileOptions{}
 	for _, opt := range opts {

--- a/atomic.go
+++ b/atomic.go
@@ -5,16 +5,36 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
+
+type FileOptions struct {
+	mode fs.FileMode
+}
+
+type Option func(*FileOptions)
+
+func FileMode(mode fs.FileMode) Option {
+	return func(opts *FileOptions) {
+		opts.mode = mode
+	}
+}
 
 // WriteFile atomically writes the contents of r to the specified filepath.  If
 // an error occurs, the target file is guaranteed to be either fully written, or
 // not written at all.  WriteFile overwrites any file that exists at the
 // location (but only if the write fully succeeds, otherwise the existing file
-// is unmodified).
-func WriteFile(filename string, r io.Reader) (err error) {
+// is unmodified).  Permissions are copied from an existing file or the FileMode
+// option can be given to be used instead of the default `0600` from
+// ioutil.TempFile().
+func WriteFile(filename string, r io.Reader, opts ...Option) (err error) {
+	fopts := &FileOptions{}
+	for _, opt := range opts {
+		opt(fopts)
+	}
+
 	// write to a temp file first, then we'll atomically replace the target file
 	// with the temp file.
 	dir, file := filepath.Split(filename)
@@ -42,6 +62,12 @@ func WriteFile(filename string, r io.Reader) (err error) {
 	// fsync is important, otherwise os.Rename could rename a zero-length file
 	if err := f.Sync(); err != nil {
 		return fmt.Errorf("can't flush tempfile %q: %v", name, err)
+	}
+	// when optional mode was given change default mode of temp file.
+	if fopts.mode != 0 {
+		if err := f.Chmod(fopts.mode); err != nil {
+			return fmt.Errorf("cannot change file mode %q: %v", name, err);
+		}
 	}
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("can't close tempfile %q: %v", name, err)

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -1,0 +1,39 @@
+package atomic
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestWriteFile(t *testing.T) {
+	file := "foo.txt"
+	content := bytes.NewBufferString("foo")
+	defer func() { _ = os.Remove(file) }()
+	if err := WriteFile(file, content); err != nil {
+		t.Errorf("Failed to write file: %q: %v", file, err)
+	}
+	fi, err := os.Stat(file)
+	if err != nil {
+		t.Errorf("Failed to stat file: %q: %v", file, err)
+	}
+	if fi.Mode() != 0600 {
+		t.Errorf("File mode not correct")
+	}
+}
+
+func TestWriteFileMode(t *testing.T) {
+	file := "bar.txt"
+	content := bytes.NewBufferString("bar")
+	defer func() { _ = os.Remove(file) }()
+	if err := WriteFile(file, content, FileMode(0644)); err != nil {
+		t.Errorf("Failed to write file: %q: %v", file, err)
+	}
+	fi, err := os.Stat(file)
+	if err != nil {
+		t.Errorf("Failed to stat file: %q: %v", file, err)
+	}
+	if fi.Mode() != 0644 {
+		t.Errorf("File mode not correct")
+	}
+}

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -36,4 +36,18 @@ func TestWriteDefaultFileMode(t *testing.T) {
 	if fi.Mode() != 0644 {
 		t.Errorf("File mode not correct")
 	}
+	// check if file mode is preserved
+	if err := os.Chmod(file, 0600); err != nil {
+		t.Errorf("Failed to change file mode: %q: %v", file, err)
+	}
+	if err := WriteFile(file, content, DefaultFileMode(0644)); err != nil {
+		t.Errorf("Failed to write file: %q: %v", file, err)
+	}
+	fi, err = os.Stat(file)
+	if err != nil {
+		t.Errorf("Failed to stat file: %q: %v", file, err)
+	}
+	if fi.Mode() != 0600 {
+		t.Errorf("File mode not correct")
+	}
 }

--- a/atomic_test.go
+++ b/atomic_test.go
@@ -22,11 +22,11 @@ func TestWriteFile(t *testing.T) {
 	}
 }
 
-func TestWriteFileMode(t *testing.T) {
+func TestWriteDefaultFileMode(t *testing.T) {
 	file := "bar.txt"
 	content := bytes.NewBufferString("bar")
 	defer func() { _ = os.Remove(file) }()
-	if err := WriteFile(file, content, FileMode(0644)); err != nil {
+	if err := WriteFile(file, content, DefaultFileMode(0644)); err != nil {
 		t.Errorf("Failed to write file: %q: %v", file, err)
 	}
 	fi, err := os.Stat(file)


### PR DESCRIPTION
Something about #12 didn't feel right or clean enough, so here's an alternative approach using the options pattern instead.
While this increases complexity a bit, it comes with the benefit of a clean interface in case of further options.